### PR TITLE
improve testability

### DIFF
--- a/foo.go
+++ b/foo.go
@@ -1,0 +1,82 @@
+package foo
+
+type foo struct {
+}
+
+func (f *foo) Gossip(peerID string, addr string) {
+	peers := peermap.PeerIDs()
+	rand.shuffle(peers)
+
+	m := []byte{}
+	m.push(TypeDigestRequest)
+	for peerid in peers
+	  digest = peermap.digest(peerid)
+	  digestEnc = encodedigest(digest)
+	  if len(m) + len(digest) > max payload size
+	    break
+	  m.push(digest)
+
+	f.transport.Send(addr, digest)
+}
+
+func (f *foo) Seed() {
+	if g.seedCB == nil {
+		g.logger.Debug("no seed cb; skipping")
+		return
+	}
+
+	seeds := g.seedCB()
+
+	g.logger.Debug("seeding gossiper", zap.Strings("seeds", seeds))
+
+	for _, addr := range seeds {
+		// Ignore ourselves.
+		if addr == g.BindAddr() {
+			continue
+		}
+		g.gossip("seed", addr)
+	}
+}
+
+func (f *foo) OnMessage(b []byte) {
+	type = b[0]
+
+	switch type
+	  digest request => onDigestRequest(decodeDigest(...))
+	  digest responds => onDigestResponds(decodeDigest(...))
+	  delta => onDelta(decodeDelta(...))
+}
+
+func (f *foo) onDigestRequest(req []digest) {
+	// any peers in digest not local just add locally
+
+	peersByVersionDiff = ...
+	// iterate in order of largest version diff
+	deltaResp = []byte{}
+	deltaResp.push(TypeDelta)
+	for peer in peersByVersionDiff)
+	  for deltaEntry in peermap.Deltas(peerid, digestEntry)
+	    deltaEnctyEnc = encodeDeltaEntry
+		if len(...) > max payload size
+		  break
+		deltaResp.push
+
+	f.transport.Send(addr, digest)
+
+	digestResp = []byte
+	digestResp.push(typeDigestResponds)
+	for revers iter peersByVersionDiff
+	  if digestEntry.version > local version
+	    // add to digest resp
+
+	f.transport.Send(..., digestResp)
+}
+
+func (f *foo) onDigestResponds(resp []digest) {
+	same as onDigestRequest except dont send digest resp
+}
+
+func (f *foo) onDelta(resp delta) {
+	for entry in delta
+	  f.peermap.updateRemote(entry.peerID, ...)
+}

--- a/gossip.go
+++ b/gossip.go
@@ -162,7 +162,7 @@ func (g *Gossip) gossipLoop() {
 func (g *Gossip) round() {
 	if len(g.peerMap.Peers()) == 0 {
 		// If we don't know about any other peers in the cluster re-seed.
-		g.seed()
+		g.foo.Seed()
 		return
 	}
 
@@ -173,60 +173,62 @@ func (g *Gossip) round() {
 	if !ok {
 		return
 	}
-	g.gossip(peer, addr)
+	g.foo.Gossip(peer, addr)
 }
 
-func (g *Gossip) seed() {
-	if g.seedCB == nil {
-		g.logger.Debug("no seed cb; skipping")
-		return
-	}
-
-	seeds := g.seedCB()
-
-	g.logger.Debug("seeding gossiper", zap.Strings("seeds", seeds))
-
-	for _, addr := range seeds {
-		// Ignore ourselves.
-		if addr == g.BindAddr() {
-			continue
-		}
-		g.gossip("seed", addr)
-	}
-}
+// func (g *Gossip) seed() {
+// 	if g.seedCB == nil {
+// 		g.logger.Debug("no seed cb; skipping")
+// 		return
+// 	}
+// 
+// 	seeds := g.seedCB()
+// 
+// 	g.logger.Debug("seeding gossiper", zap.Strings("seeds", seeds))
+// 
+// 	for _, addr := range seeds {
+// 		// Ignore ourselves.
+// 		if addr == g.BindAddr() {
+// 			continue
+// 		}
+// 		g.gossip("seed", addr)
+// 	}
+// }
 
 func (g *Gossip) onPacket(p *Packet) {
-	responses, err := g.protocol.OnMessage(p.Buf)
-	if err != nil {
-		return
-	}
-	for _, b := range responses {
-		_, err := g.transport.WriteTo(b, p.From.String())
-		if err != nil {
-			g.logger.Error("failed to write to transport", zap.Error(err))
-			return
-		}
-	}
+	f.foo.OnMessage(p.Buf)
+
+	// responses, err := g.protocol.OnMessage(p.Buf)
+	// if err != nil {
+	// 	return
+	// }
+	// for _, b := range responses {
+	// 	_, err := g.transport.WriteTo(b, p.From.String())
+	// 	if err != nil {
+	// 		g.logger.Error("failed to write to transport", zap.Error(err))
+	// 		return
+	// 	}
+	// }
 }
 
-func (g *Gossip) gossip(id string, addr string) error {
-	g.logger.Debug(
-		"gossip with peer",
-		zap.String("id", id),
-		zap.String("addr", addr),
-	)
-
-	b, err := g.protocol.DigestRequest()
-	if err != nil {
-		g.logger.Error("failed to get digest reqeust", zap.Error(err))
-		return err
-	}
-
-	_, err = g.transport.WriteTo(b, addr)
-	if err != nil {
-		g.logger.Error("failed to write to transport", zap.Error(err))
-		return fmt.Errorf("failed to write to transport %s: %v", addr, err)
-	}
-
-	return nil
-}
+// func (g *Gossip) gossip(id string, addr string) error {
+// 	g.logger.Debug(
+// 		"gossip with peer",
+// 		zap.String("id", id),
+// 		zap.String("addr", addr),
+// 	)
+// 
+// 	b, err := g.protocol.DigestRequest()
+// 	if err != nil {
+// 		g.logger.Error("failed to get digest reqeust", zap.Error(err))
+// 		return err
+// 	}
+// 
+// 	_, err = g.transport.WriteTo(b, addr)
+// 	if err != nil {
+// 		g.logger.Error("failed to write to transport", zap.Error(err))
+// 		return fmt.Errorf("failed to write to transport %s: %v", addr, err)
+// 	}
+// 
+// 	return nil
+// }


### PR DESCRIPTION
This aims to try and make testing of the library easier prior to replacing the encoding with a binary protocol. Right now too much logic is in `gossip.go` which is hard to unit test given it includes timers and goroutines etc. Instead will move that logic into another file, so all gossip does it setup config, and start the goroutine with a gossip interval timer.

TODO